### PR TITLE
House Keeping: requirements/ model update

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ def frames_to_story(base64Frames, prompt, api_key):
         },
     ]
     params = {
-        "model": "gpt-4-vision-preview",
+        "model": "gpt-4o-mini",
         "messages": PROMPT_MESSAGES,
         "api_key": api_key,
         "headers": {"Openai-Version": "2020-11-07"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ IPython
 openai==0.28
 moviepy
 streamlit
-tempfile
-OpenCV
+temp
+opencv-python


### PR DESCRIPTION
- GPT4-V Preview model deprecated, moving to 4-o mini
- The PyPi manifests for tempfile & OpenCV are [temp](https://pypi.org/project/temp/) and [opencv-python](https://pypi.org/project/opencv-python/) respectively